### PR TITLE
feat: use JWT for topic subscription

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -18,7 +18,6 @@ jobs:
         image: dunglas/mercure:latest
         env:
           JWT_KEY: '!ChangeMe!'
-          ALLOW_ANONYMOUS: 1
         ports:
           - 80:80
 

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,34 @@
+name: Dart CI
+
+on:
+  push: ~
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: google/dart:latest
+
+    services:
+      mercure:
+        image: dunglas/mercure:latest
+        env:
+          JWT_KEY: '!ChangeMe!'
+          ALLOW_ANONYMOUS: 1
+        ports:
+          - 80:80
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: pub get
+      - name: Run tests
+        run: pub run test
+      - name: Dart/Flutter Package Analyzer
+        uses: axel-op/dart-package-analyzer@v2.0.0
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Dart library for [dunglas/mercure](https://github.com/dunglas/mercure)
 
 [![pipeline status](https://gitlab.com/wallforfry/dart_mercure/badges/master/pipeline.svg)](https://gitlab.com/wallforfry/dart_mercure/commits/master)
+![Dart CI](https://github.com/wallforfry/dart_mercure/workflows/Dart%20CI/badge.svg)
 [![pub package](https://img.shields.io/pub/v/dart_mercure.svg)](https://pub.dev/packages/dart_mercure)
 
 - This library allow to communicate with dunglas/mercure.

--- a/example/dart_mercure_example.dart
+++ b/example/dart_mercure_example.dart
@@ -1,15 +1,15 @@
 import 'package:dart_mercure/dart_mercure.dart';
 
-main() {
+void main() {
   // Token generate with "mercure" JWT_KEY
-  String token =
-      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InN1YnNjcmliZSI6WyIqIl0sInB1Ymxpc2giOlsiKiJdfX0.Gfj3BFrSOFhyFN0hPOYg-Pe4dfYWOKq7QJiMWYC2Z_k";
-  String hub_url = "http://mercure/hub";
-  String topic = "http://mercure/test";
+  var token =
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InN1YnNjcmliZSI6WyIqIl0sInB1Ymxpc2giOlsiKiJdfX0.Gfj3BFrSOFhyFN0hPOYg-Pe4dfYWOKq7QJiMWYC2Z_k';
+  var hub_url = 'http://mercure/hub';
+  var topic = 'http://mercure/test';
 
-  Mercure mercure = Mercure(token: token, hub_url: hub_url);
+  var mercure = Mercure(token: token, hub_url: hub_url);
   mercure.subscribeTopics(
-      topics: <String>[topic, "2"],
+      topics: <String>[topic, '2'],
       onData: (Event event) {
         print(event.data);
       });
@@ -20,9 +20,9 @@ main() {
         print(event.data);
       });
 
-  mercure.publish(topic: topic, data: "DATA").then((status) {
+  mercure.publish(topic: topic, data: 'DATA').then((status) {
     if (status == 200) {
-      print("Message Sent");
+      print('Message Sent');
     } else {
       print('Message Failed with code : $status');
     }

--- a/lib/src/dart_mercure_auth_client.dart
+++ b/lib/src/dart_mercure_auth_client.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+import 'package:http/http.dart' as http;
+
+class AuthClient extends http.BaseClient {
+
+  final String _token;
+  final http.Client _inner;
+
+  AuthClient(this._token, this._inner);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    request.headers['Authorization'] = 'Bearer $_token';
+    return _inner.send(request);
+  }
+}

--- a/lib/src/dart_mercure_auth_client.dart
+++ b/lib/src/dart_mercure_auth_client.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'package:http/http.dart' as http;
 
 class AuthClient extends http.BaseClient {
-
   final String _token;
   final http.Client _inner;
 

--- a/lib/src/dart_mercure_base.dart
+++ b/lib/src/dart_mercure_base.dart
@@ -1,3 +1,4 @@
+import 'package:dart_mercure/src/dart_mercure_auth_client.dart';
 import 'package:eventsource/eventsource.dart';
 import 'dart:async';
 import 'package:http/http.dart' as http;
@@ -6,10 +7,12 @@ import 'package:meta/meta.dart';
 class Mercure {
   final String hub_url;
   final String token;
+  final http.Client _client;
 
-  Mercure({@required this.hub_url, this.token})
+  Mercure({@required this.hub_url, @required this.token})
       : assert(hub_url != null),
-        assert(token != null);
+        assert(token != null),
+        _client = AuthClient(token, http.Client());
 
   /// Subscribe to one mercure topic
   StreamSubscription<Event> subscribeTopic(
@@ -34,7 +37,7 @@ class Mercure {
       void onDone(),
       bool cancelOnError}) {
     String params = topics.map((topic) => 'topic=$topic&').join();
-    EventSource.connect('$hub_url?$params').then((eventSource) {
+    EventSource.connect('$hub_url?$params', client: _client).then((eventSource) {
       eventSource.listen(onData,
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);
     });
@@ -42,9 +45,8 @@ class Mercure {
 
   /// Publish data in mercure topic
   Future<int> publish({@required String topic, @required String data}) async {
-    var response = await http.post(this.hub_url,
-        body: {'topic': topic, 'data': data},
-        headers: {'Authorization': 'Bearer $token'});
+    var response = await _client.post(hub_url,
+        body: {'topic': topic, 'data': data});
     return response.statusCode;
   }
 }

--- a/lib/src/dart_mercure_base.dart
+++ b/lib/src/dart_mercure_base.dart
@@ -17,9 +17,9 @@ class Mercure {
   /// Subscribe to one mercure topic
   StreamSubscription<Event> subscribeTopic(
       {@required String topic,
-      @required void onData(Event event),
+      @required void Function(Event event) onData,
       Function onError,
-      void onDone(),
+      void Function() onDone,
       bool cancelOnError}) {
     subscribeTopics(
         topics: <String>[topic],
@@ -32,11 +32,11 @@ class Mercure {
   /// Subscribe to a list of mercure topics
   StreamSubscription<Event> subscribeTopics(
       {@required List<String> topics,
-      @required void onData(Event event),
+      @required void Function(Event event) onData,
       Function onError,
-      void onDone(),
+      void Function() onDone,
       bool cancelOnError}) {
-    String params = topics.map((topic) => 'topic=$topic&').join();
+    var params = topics.map((topic) => 'topic=$topic&').join();
     EventSource.connect('$hub_url?$params', client: _client).then((eventSource) {
       eventSource.listen(onData,
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);

--- a/test/dart_mercure_test.dart
+++ b/test/dart_mercure_test.dart
@@ -10,34 +10,34 @@ void main() {
     String topic;
 
     setUp(() {
-      topic = "http://mercure/test";
+      topic = 'https://mercure/test';
       token =
-          "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InN1YnNjcmliZSI6WyIqIl0sInB1Ymxpc2giOlsiKiJdfX0.Gfj3BFrSOFhyFN0hPOYg-Pe4dfYWOKq7QJiMWYC2Z_k";
-      hub_url = "http://mercure/hub";
+          'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InN1YnNjcmliZSI6WyIqIl0sInB1Ymxpc2giOlsiKiJdfX0.YIcYqBdnLwiweTIo6my83ryFyBNKxJ8m5Cy426Du3WI';
+      hub_url = 'http://mercure/.well-known/mercure';
       mercure = Mercure(token: token, hub_url: hub_url);
     });
 
     test('Subscribe Topic', () {
-      String value = "NODATA";
+      var value = 'NODATA';
       mercure.subscribeTopic(
           topic: topic,
           onData: (Event event) {
             value = event.data;
           });
       Future.delayed(const Duration(seconds: 1), () {
-        mercure.publish(topic: topic, data: "DATA").then((_) {
-          expect(value, "DATA");
+        mercure.publish(topic: topic, data: 'DATA').then((_) {
+          expect(value, 'DATA');
         });
       });
     });
 
     test('Test Publish', () async {
-      expect(await mercure.publish(topic: topic, data: "DATA"), 200);
+      expect(await mercure.publish(topic: topic, data: 'DATA'), 200);
     });
 
     test('Test Publish bad token', () async {
-      mercure_bad_token = Mercure(token: token + "A", hub_url: hub_url);
-      expect(await mercure_bad_token.publish(topic: topic, data: "DATA"), 401);
+      mercure_bad_token = Mercure(token: token + 'A', hub_url: hub_url);
+      expect(await mercure_bad_token.publish(topic: topic, data: 'DATA'), 401);
     });
   });
 }


### PR DESCRIPTION
Hey,

thanks for this great package! When experimenting with it, I found that the JWT is not used for topic subscription. Since I want to disable `ALLOW_ANONYMOUS` in my project using Mercure, I decided to provide this PR.

This PR:
* uses the JWT for both `subscribe` and `publish`
* adds a GitHub Action workflow for automated testing and analysis

Please have a look at it and give me some feedback.

Thanks,
best @cawolf